### PR TITLE
Update generated files for java-maven-pipeline-example : gh-maven-build (catalog-info.yaml)

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -131,10 +131,12 @@ jobs:
         working-directory: ./
         run: |
           ARTIFACT_NAME="${ARTIFACT_ID}-${PROJECT_VERSION}.${PACKAGE_TYPE}"
-          mvn --batch-mode -Dmaven.test.skip=true -Pgithub deploy --file ./pom.xml
+          mvn --batch-mode -Dmaven.test.skip=true -Pgithub deploy --settings ./settings.xml --file ./pom.xml
           echo "artifact_sha256=$(sha256sum ./target/${ARTIFACT_NAME} | awk '{ print $1 }')" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           PROJECT_VERSION: ${{ steps.set-build-output-parameters.outputs.project_version }}
           ARTIFACT_ID: ${{ steps.set-build-output-parameters.outputs.artifact_id }}
           PACKAGE_TYPE: ${{ steps.set-build-output-parameters.outputs.package_type }}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,7 +24,7 @@ metadata:
     playbook.io.nrs.gov.bc.ca/clientId: e985d455-b0ff-470b-8731-e004fcfac915
     license: Apache-2.0
     composer.io.nrs.gov.bc.ca/generators: backstage,gh-maven-build
-    composer.io.nrs.gov.bc.ca/skipAutomatedScan: true
+    composer.io.nrs.gov.bc.ca/skipAutomatedScan: false
     playbook.io.nrs.gov.bc.ca/deployJasperReports: false
     playbook.io.nrs.gov.bc.ca/configureNrArtifactory: false
     playbook.io.nrs.gov.bc.ca/mavenBuildCommand: --batch-mode -Dmaven.test.skip=true -Pgithub deploy --file ./pom.xml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,6 +24,7 @@ metadata:
     playbook.io.nrs.gov.bc.ca/clientId: e985d455-b0ff-470b-8731-e004fcfac915
     license: Apache-2.0
     composer.io.nrs.gov.bc.ca/generators: backstage,gh-maven-build
+    composer.io.nrs.gov.bc.ca/skipAutomatedScan: true
     playbook.io.nrs.gov.bc.ca/deployJasperReports: false
     playbook.io.nrs.gov.bc.ca/configureNrArtifactory: false
     playbook.io.nrs.gov.bc.ca/mavenBuildCommand: --batch-mode -Dmaven.test.skip=true -Pgithub deploy --file ./pom.xml


### PR DESCRIPTION
                        This PR updates generated files for java-maven-pipeline-example using the gh-maven-build generator from catalog-info.yaml.

                        ✅ This PR is ready to be merged.
 
                        If this PR has merge conflicts, please refer to the [instructions](https://github.com/bcgov/nr-repository-composer/blob/main/README.md) to run the composer manually and update this branch.
                        After merging this PR:
                         - a new release should be tagged on the [releases](https://github.com/bcgov/java-maven-pipeline-example/releases) page
                         - any actively developed branches should be updated to include these changes
 